### PR TITLE
ttc-connectors-ranking to 1.0.20

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,6 +16,9 @@ dependencies:
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.42
+- name: ttc-connectors-ranking
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.20
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.24


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.20