### PR TITLE
activiti-cloud-modeling to 7.0.12

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: activiti-cloud-modeling
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.11
+  version: 7.0.12
 - alias: expose
   name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io


### PR DESCRIPTION
Promote activiti-cloud-modeling to version 7.0.12